### PR TITLE
Drag and fill

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,10 +20,24 @@
       <!-- each "column class is a column" -->
       <div class="column">
         <!-- number of "box" divs determines the number of rows -->
-        <div class="box" onClick="setCellColor(event)"></div>
+        <div 
+            class="box" 
+            onClick="setCellColor(event)" 
+            onmousedown="dragStart(event)" 
+            onmouseover="dropColors(event)"
+            onmouseup="dragEnd(event)"
+            >
+        </div>
       </div>
       <div class="column">
-        <div class="box" onClick="setCellColor(event)"></div>
+        <div 
+            class="box" 
+            onClick="setCellColor(event)" 
+            onmousedown="dragStart(event)" 
+            onmouseover="dropColors(event)"
+            onmouseup="dragEnd(event)"
+            >
+        </div>
       </div>
     </div>
 

--- a/script.js
+++ b/script.js
@@ -9,6 +9,9 @@ function addRow(){ //add a row when called
         const newDiv = document.createElement('div')
         newDiv.setAttribute('class', "box")
         newDiv.addEventListener('click', setCellColor) // add event listener to set color when clicked
+        newDiv.addEventListener("mousedown", dragStart) // add event listener to record beginning of drag & drop
+        newDiv.addEventListener("mouseover", dropColors) // set color of box when mouse is held down
+        newDiv.addEventListener("mouseup", dragEnd) // add event listener to record ending of drag & drop
 
         //append the div element to the end of every row, effectively creating a new row
         item.append(newDiv)
@@ -54,7 +57,11 @@ function addColumn(){ //adds a column when called
         //create a new div element with the class attribute of "box"
         const newDiv = document.createElement('div')
         newDiv.setAttribute('class', "box")
-        newDiv.addEventListener('click', setCellColor) // add event listener to set color when clicked
+        newDiv.addEventListener('click', setCellColor) // set color when clicked
+        newDiv.addEventListener("mousedown", dragStart) // record beginning box of drag & drop
+        newDiv.addEventListener("mouseover", dropColors) // set color of box when mouse is held down
+        newDiv.addEventListener("mouseup", dragEnd) // record ending box of drag & drop
+
 
         //append the div element to the end of every column
         newCol.append(newDiv)
@@ -128,4 +135,33 @@ function fillUncoloredCells() {
             box.style.backgroundColor = selectedColor
     }
 
+}
+
+////////////////////////////////////////////////////////////////////////
+
+
+// The below code is for the drag and drop feature
+
+const bodyEl = document.getElementsByTagName("body")
+bodyEl[0].addEventListener("mouseup", dragEnd) // record ending box of drag & drop
+
+// The above event listener is needed to prevent the event ending outside the div
+// Since in that case, we can't listen to it and the user can keep painting colors.
+
+let dragAndDrop = false
+
+function dragStart(event) {
+    dragAndDrop = true
+    event.target.style.backgroundColor = selectedColor
+}
+
+function dragEnd(event) {
+    dragAndDrop = false
+}
+
+function dropColors(event) {
+    if (dragAndDrop) {
+        console.log(event.target)
+        event.target.style.backgroundColor = selectedColor
+    }
 }

--- a/script.js
+++ b/script.js
@@ -167,6 +167,7 @@ function dropColors(event) {
 // The code below is a function that goes through each cell in the grid.
 // For each cell, it sets the color to the selected color regardless of the current color of the cell
 
+}
 
 function fillAllCells() {
     // grab existing boxes
@@ -195,5 +196,4 @@ function clearColors() {
         //and set the color to transparent
         box.style.backgroundColor = "transparent"
     }
-
 }


### PR DESCRIPTION
Adds event listeners to grid cells for mousedown, mouseover, and mouseup events. Adds an event listener to the body for mouseup in case the user lets go of their mouse outside the box.

Known bug: When clicking the edges of a grid cells, the mouse changes to a "Not Allowed" symbol. Once the mouse is let go, the user can freely color without clicking and holding again.

Resolves issue #1 