### PR TITLE
Fixed bug with drag & drop, added awesome styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,70 +1,57 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>My Page Title</title>
-  <meta name="description" content="My Page Description">
-  <link rel="stylesheet" href="./style.css">
-</head>
-<body>
+  <head>
+    <meta charset="utf-8" />
+    <title>My Page Title</title>
+    <meta name="description" content="My Page Description" />
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <h1>Tile Painter</h1>
+    <h2 id="max-column-message"></h2>
+    <div class="buttons">
+      <button onclick="addRow()" id="add-row">Add Row</button>
+      <button onclick="removeRow()" id="remove-row">Remove row</button>
+      <button onclick="addColumn()" id="add-column">Add Column</button>
+      <button onclick="removeColumn()" id="remove-column">Remove Column</button>
+      <button onClick="fillUncoloredCells()">Fill Uncolored Cells</button>
+      <button onClick="fillAllCells()">Fill All Cells</button>
+      <button onClick="clearColors()">Clear All Cells</button>
+    </div>
 
-
-    <button onclick="addRow()" id="add-row">Add Row</button>
-    <button onclick="removeRow()" id="remove-row">Remove row</button>
-    <button onclick="addColumn()" id="add-column">Add Column</button>
-    <button onclick="removeColumn()" id="remove-column">Remove Column</button>
-    <button onClick="fillUncoloredCells()">Fill Uncolored Cells</button>
-    <button onClick="fillAllCells()">Fill All Cells</button>
-    <button onClick="clearColors()">Clear All Cells</button>
-    
-    <div id='grid-board'>  
-
-      <!-- each "column class is a column" -->
-      <div class="column">
-        <!-- number of "box" divs determines the number of rows -->
-        <div 
-            class="box" 
-            onClick="setCellColor(event)" 
-            onmousedown="dragStart(event)" 
-            onmouseover="dropColors(event)"
-            onmouseup="dragEnd(event)"
-            >
-        </div>
-      </div>
-      <div class="column">
-        <div 
-            class="box" 
-            onClick="setCellColor(event)" 
-            onmousedown="dragStart(event)" 
-            onmouseover="dropColors(event)"
-            onmouseup="dragEnd(event)"
-            >
-        </div>
+    <div class="selectColor">
+      <div>
+        <label for="color">Select a Color</label>
+        <select name="color" id="color-selector">
+          <option value="transparent">Transparent</option>
+          <option value="red">Red</option>
+          <option value="orange">Orange</option>
+          <option value="yellow">Yellow</option>
+          <option value="green">Green</option>
+          <option value="blue">Blue</option>
+          <option value="indigo">Indigo</option>
+          <option value="violet">Violet</option>
+          <option value="brown">Brown</option>
+          <option value="black">Black</option>
+          <option value="white">White</option>
+        </select>
       </div>
     </div>
 
-
-   
-    
-    <label for="color">Select a Color</label>
-    <select name="color" id="color-selector">
-
-        <option value="transparent">Transparent</option>
-        <option value="red">Red</option>
-        <option value="orange">Orange</option>
-        <option value="yellow">Yellow</option>
-        <option value="green">Green</option>
-        <option value="blue">Blue</option>
-        <option value="indigo">Indigo</option>
-        <option value="violet">Violet</option>
-        <option value="brown">Brown</option>
-        <option value="black">Black</option>
-        <option value="white">White</option>
-
-    </select>
-
-
+    <div id="grid-board">
+      <!-- each "column class is a column" -->
+      <div class="column">
+        <!-- number of "box" divs determines the number of rows -->
+        <div
+          class="box"
+          onClick="setCellColor(event)"
+          onmousedown="dragStart(event)"
+          onmouseover="dropColors(event)"
+          onmouseup="dragEnd(event)"
+        ></div>
+      </div>
+    </div>
 
     <script type="text/javascript" src="./script.js"></script>
-</body>
+  </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,6 @@
-
+var colCounter = 1 // keeps count of number of columns
+var colMax = 10 // columns should not exceed 10 in order to fit on most windows
+const maxColMessage = document.getElementById("max-column-message")
 
 function addRow(){ //add a row when called
     //grab all the existing columns
@@ -8,9 +10,9 @@ function addRow(){ //add a row when called
         //create a new div element with the class attribute of "box"
         const newDiv = document.createElement('div')
         newDiv.setAttribute('class', "box")
-        newDiv.addEventListener('click', setCellColor) // add event listener to set color when clicked
-        newDiv.addEventListener("mousedown", dragStart) // add event listener to record beginning of drag & drop
+        // newDiv.addEventListener('click', setCellColor) // add event listener to set color when clicked
         newDiv.addEventListener("mouseover", dropColors) // set color of box when mouse is held down
+        newDiv.addEventListener("mousedown", dragStart) // add event listener to record beginning of drag & drop
         newDiv.addEventListener("mouseup", dragEnd) // add event listener to record ending of drag & drop
 
         //append the div element to the end of every row, effectively creating a new row
@@ -40,6 +42,17 @@ function removeRow(){ //removes a row when called
 
 
 function addColumn(){ //adds a column when called
+
+    // return if max columns reached, otherwise increment by 1
+    if (colCounter >= colMax) {
+        maxColMessage.innerText = "Maximum Columns Reached!"
+        return
+    }
+    else
+        colCounter++
+
+    
+    
     //grab the grid
     const grid = document.getElementById('grid-board')
     //create a new div...
@@ -57,11 +70,11 @@ function addColumn(){ //adds a column when called
         //create a new div element with the class attribute of "box"
         const newDiv = document.createElement('div')
         newDiv.setAttribute('class', "box")
-        newDiv.addEventListener('click', setCellColor) // set color when clicked
-        newDiv.addEventListener("mousedown", dragStart) // record beginning box of drag & drop
+        // newDiv.addEventListener('click', setCellColor) // set color when clicked
         newDiv.addEventListener("mouseover", dropColors) // set color of box when mouse is held down
+        newDiv.addEventListener("mousedown", dragStart) // record beginning box of drag & drop
         newDiv.addEventListener("mouseup", dragEnd) // record ending box of drag & drop
-
+        
 
         //append the div element to the end of every column
         newCol.append(newDiv)
@@ -72,15 +85,18 @@ function addColumn(){ //adds a column when called
 }
 
 function removeColumn(){ //removes a column when called
+    
     const grid = document.getElementById('grid-board')
     const cols = grid.getElementsByClassName('column')
     if(cols.length > 1){ ////makes sure theres at least one column remaining
+        colCounter--
         cols[cols.length - 1 ].remove()
     } 
+
+    // Sets text to empty to get rid of message
+    if (colCounter === colMax - 1)
+        maxColMessage.innerText = ""
 }
-
-
-
 
 
 
@@ -95,6 +111,7 @@ const colorSelectorEl = document.getElementById("color-selector")
 let selectedColor = "transparent"
 
 const setColor = (event) => {
+    
     selectedColor = colorSelectorEl.value
 }
 
@@ -153,15 +170,18 @@ let dragAndDrop = false
 function dragStart(event) {
     dragAndDrop = true
     event.target.style.backgroundColor = selectedColor
+    console.log("mouse down")
 }
 
 function dragEnd(event) {
     dragAndDrop = false
+    console.log("mouse up")
 }
 
 function dropColors(event) {
+    console.log("mouse over")
     if (dragAndDrop) {
-        console.log(event.target)
+        console.log("mouse over set color")
         event.target.style.backgroundColor = selectedColor
     }
 // The code below is a function that goes through each cell in the grid.

--- a/style.css
+++ b/style.css
@@ -1,12 +1,57 @@
+/* RAINBOW TEXT!!! Credit to Rahul @ https://w3bits.com/rainbow-text/ */
+@keyframes rainbow {
+    0% {
+        background-position: 0% 50%;
+    }
+
+    50% {
+        background-position: 100% 25%;
+    }
+
+    100% {
+        background-position: 0% 50%;
+    }
+}
+
+
 body {
     margin: 0;
     color: white;
     background-color:darkcyan;
+    user-select: none;
 }
 
+h1 {
+    margin: 50px auto;
+    text-align: center;
+    font-size: 100px;
+    background-image: repeating-linear-gradient(45deg, violet, indigo, blue, green, yellow, orange, red, violet);
+    text-align: center;
+    background-size: 800% 800%;
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    animation: rainbow 8s ease infinite;
+    width: 900px;
+}
+
+h2 {
+    width: 900px;
+    margin: 0 auto;
+    text-align: center;
+    font-size: 50px;
+    color: red;
+}
 
 #grid-board{
+    margin: auto;
+    margin-top: 25px;
+    padding: 50px;
     display: flex;
+    justify-content: center;
+    height: 90%;
+    width: 90%;
+    /* border: solid 5px rgb(205, 217, 255) */
 }
 
 .box{
@@ -17,11 +62,44 @@ body {
 }
 
 
+.buttons {
+    margin: 25px auto;
+    display: flex;
+    justify-content: center;
+    width: 1400px;
+}
+
+
 button {
     margin: 10px;
     padding: 10px;
     border-radius: 10px;
     border-style: none;
-    background-color: rgb(51, 180, 255);
-    color: white
+    background: linear-gradient(120deg, rgb(6, 112, 173) 20%, rgb(51, 180, 255) 100%);
+    box-shadow: 10px 10px 5px 5px rgba(0, 0, 0, 0.1);
+    color: white;
+    font-size: 25px;
+}
+
+button:active {
+    box-shadow: inset 5px 5px 10px -3px rgba(0, 0, 0, 0.7);
+}
+
+.selectColor {
+    margin: auto;
+    display: flex;
+    justify-content: space-evenly;
+    width: 900px;
+}
+
+.selectColor label {
+    font-size: 25px;
+}
+
+.selectColor select {
+    border-radius: 25px;
+    border-style: none;
+    font-size: 20px;
+    margin-left: 5px;
+    padding: 5px
 }


### PR DESCRIPTION
Resolves #1   

This commit fixes a bug with the drag and drop where the user can paint
multiple tiles without clicking the mouse. The cause of this bug was
difficult to pin down. Essentially, when a user clicks a cell and tries
to drag it, their cursor would sometimes change to a "Not allowed"
symbol (circle with a slash across it). This would cause the mouse up
event to not register when the user releases their mouse, allowing them
to paint tiles without holding down the mouse key.

Based on several rounds of testing and debugging, it seems that this
occurs because the user is selecting the empty div element contents
(think of dragging and dropping text from a page into the search bar).
The "Not Allowed" symbol appears because the current spot the user is at
is not a valid place to drop the content, but they are allowed to drop
it in a text box.

Understanding this, the bug can be solved by setting the "user-select"
CSS property to the value "none", which prevents a user from selecting
text from elements that have this property. This property was added to
the body element, and it seems to have fixed the bug.

Additionally, the front page was styled using fancy CSS properties. It
is my first time using these properties, but they seem to have the
effect I was going for. Play around with them and check out the MDN docs
to see how they work--they're pretty cool!